### PR TITLE
Reverted last edit to Readme and added some clarification

### DIFF
--- a/README
+++ b/README
@@ -7,10 +7,13 @@ It's in order of magnitude faster (and uses much less memory) than the latter.
 For the original work please see:
 http://tartarus.org/~martin/PorterStemmer/
 
+Gemfile:
+  gem 'fast-stemmer'
+
 Usage:
 
   require 'rubygems'
-  require 'fast-stemmer'
+  require 'fast_stemmer'
 
   Stemmer::stem_word('running') # -> 'run'
   'running'.stem                # -> 'run'


### PR DESCRIPTION
While the hyphen is needed for the gem name, the include file uses an underscore in the name.
